### PR TITLE
l1 rpc url is passed as env var to docker image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,13 @@
-DB_URL=""
-POSTGRES_DB=""
-POSTGRES_USER=""
-POSTGRES_PASSWORD=""
+# The postgres values are used only by docker compose 
+# Docker sets up a postgres container and uses these values to connect to it
+# These can be any values
+POSTGRES_DB="postgres"
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="postgres"
+
 VAULT_HASH=""
 UDC_ADDRESS=""
 VAULT_ADDRESS=""
-L1_URL=""
+L1_URL="" # use a websocket url i.e. "wss://ethereum-sepolia-rpc.publicnode.com"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-ENV L1_URL=${L1_URL}
+
 # Copy the Juno binary and the plugin from the build stage
 COPY --from=build /plugin/db/migrations ./db/migrations
 COPY --from=build /plugin/juno/build/juno ./build/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "6060:6060" # Adjust this port if needed
+      - "6060:6060"
 
 volumes:
   postgres_data:


### PR DESCRIPTION
How to pass the env vars to the docker image:

`docker run --env-file .env -p 6060:6060 <img_name>`

As an alternative, simply use docker compose.